### PR TITLE
Fixed: warnings on react-native 0.25.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-var React = require('react-native')
+var React = require('react')
 var tweenState = require('react-tween-state')
-var {PanResponder, TouchableHighlight, StyleSheet, Text, View} = React
+var {PanResponder, TouchableHighlight, StyleSheet, Text, View} = require('react-native')
 var styles = require('./styles.js')
 
 var SwipeoutBtn = React.createClass({

--- a/index.js
+++ b/index.js
@@ -1,7 +1,13 @@
-var React = require('react')
-var tweenState = require('react-tween-state')
-var {PanResponder, TouchableHighlight, StyleSheet, Text, View} = require('react-native')
-var styles = require('./styles.js')
+import React from 'react'
+import tweenState from 'react-tween-state'
+import {
+  PanResponder,
+  TouchableHighlight,
+  StyleSheet,
+  Text,
+  View
+} from 'react-native'
+import styles from './styles'
 
 var SwipeoutBtn = React.createClass({
   getDefaultProps: function() {

--- a/styles.js
+++ b/styles.js
@@ -1,4 +1,4 @@
-import { StyleSheet } = from 'react-native'
+import { StyleSheet } from 'react-native'
 
 var styles = StyleSheet.create({
   swipeout: {

--- a/styles.js
+++ b/styles.js
@@ -1,5 +1,4 @@
-var React = require('react-native')
-var {StyleSheet} = React
+import { StyleSheet } = from 'react-native'
 
 var styles = StyleSheet.create({
   swipeout: {


### PR DESCRIPTION
React-Native as of 0.25.x is deprecating .cloneElement() and .createElement(), instead suggesting we use those methods from the React package as opposed to React-Native.

This commit fixes those warnings and moves to es6 imports style.
