### PR TITLE
add onMoveShouldSetPanResponder to panResponder

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ class Swipeout extends React.Component {
 
     this.state.panResponder = PanResponder.create({
       onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
       onPanResponderGrant: () => {
         let {
           panX,


### PR DESCRIPTION
Swipeout doesn't work if I wrap it around TouchableOpacity because onStart is captured inside. adding onMoveShouldSetPanResponder fixes this.
