### PR TITLE
left buttons animation fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,9 +276,8 @@ const Swipeout = React.createClass({
 
     var styleLeftPos = {
       left: {
-        left: 0,
-        overflow: 'hidden',
-        width: Math.min(limit*(posX/limit), limit),
+        left: Math.min(posX - limit, 0),
+        width: limit
       },
     };
     var styleRightPos = {


### PR DESCRIPTION
#17 

Please take a look. The previous solution didn't work on android - 
without these changes, the buttons appear suddenly without animation 