### PR TITLE
Fixed: Element type invalid

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,4 +361,4 @@ const Swipeout = React.createClass({
 Swipeout.NativeButton = NativeButton;
 Swipeout.SwipeoutButton = SwipeoutBtn;
 
-export default Swipeout;
+module.exports = Swipeout;


### PR DESCRIPTION
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object. Check the render method of `StaticRenderer`