### PR TITLE
Fix to 'element type is invalid' error

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,4 +384,4 @@ const Swipeout = React.createClass({
 Swipeout.NativeButton = NativeButton;
 Swipeout.SwipeoutButton = SwipeoutBtn;
 
-export default Swipeout;
+export { Swipeout };


### PR DESCRIPTION
This is the exact error when trying to use the Swipeout component in my component using this import:
``import { Swipeout } from 'react-native-swipeout';``

<img width="364" alt="screenshot 2017-06-04 22 54 00" src="https://cloud.githubusercontent.com/assets/5825343/26768947/4a714f3a-4979-11e7-8d58-85e2a43b5064.png">

Error was fixed when changing the export statement in the index.js file to:
``export { Swipeout };``

