### PR TITLE
- Avoid Wrapping button text.

### DIFF
--- a/NativeButton.js
+++ b/NativeButton.js
@@ -58,7 +58,7 @@ const NativeButton = React.createClass({
     }
 
     return (
-      <Text style={ [ styles.textButton, this.props.textStyle ] }>
+      <Text numberOfLines={1} ellipsizeMode="clip"  style={ [ styles.textButton, this.props.textStyle ] }>
         { this.props.children }
       </Text>
     );


### PR DESCRIPTION
The buttons text wraps into multiple lines when swiping in. Adding clip with one line of text prevents this artefact.