### PR TITLE
Update PropTypes and React.createClass

### DIFF
--- a/NativeButton.js
+++ b/NativeButton.js
@@ -1,6 +1,5 @@
-import React, {
-  PropTypes,
-} from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import {
   TouchableWithoutFeedback,
@@ -27,7 +26,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const NativeButton = React.createClass({
+const NativeButton = createReactClass({
 
   propTypes: {
     // Extract parent props

--- a/index.js
+++ b/index.js
@@ -4,8 +4,9 @@ import styles from './styles';
 
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
 
 import {
   PanResponder,
@@ -15,7 +16,7 @@ import {
   View,
 } from 'react-native';
 
-const SwipeoutBtn = React.createClass({
+const SwipeoutBtn = createReactClass({
 
   propTypes: {
     backgroundColor: PropTypes.string,
@@ -92,7 +93,7 @@ const SwipeoutBtn = React.createClass({
   }
 });
 
-const Swipeout = React.createClass({
+const Swipeout = createReactClass({
   mixins: [tweenState.Mixin],
 
   propTypes: {


### PR DESCRIPTION
This PR is needed to get rid of the annoying deprecation errors, preparing the codebase for the upcoming React 16:

```
Warning: PropTypes has been moved to a separate package. Accessing React.PropTypes is no longer supported and will be removed completely in React 16. Use the prop-types package on npm instead. (https://fb.me/migrating-from-react-proptypes)
```

```
Warning: React.createClass is no longer supported. Use a plain JavaScript class instead. If you're not yet ready to migrate, create-react-class is available on npm as a drop-in replacement. (https://fb.me/migrating-from-react-create-class)
```