### PR TITLE
Support both View.propTypes and ViewPropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ const Swipeout = createReactClass({
     onClose: PropTypes.func,
     right: PropTypes.array,
     scroll: PropTypes.func,
-    style: ViewPropTypes.style,
+    style: (ViewPropTypes || View.propTypes).style,
     sensitivity: PropTypes.number,
     buttonWidth: PropTypes.number,
     disabled: PropTypes.bool,


### PR DESCRIPTION
As `ViewPropTypes` was introduced in [RN 0.44](https://github.com/facebook/react-native/releases/tag/v0.44.3) to replace `View.propTypes`, this will bring old-react-native-support back again. 