### PR TITLE
Fix babel build error (#230)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 example
 index.android.js
+.babelrc


### PR DESCRIPTION
Removing __.babelrc__ file from the NPM package prevents that babel build error. (issue #230)