### PR TITLE
Fix compile error TS2605

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 declare module 'react-native-swipeout' {
     export interface SwipeoutButtonProperties {


### PR DESCRIPTION
Fix compile error TS2605: JSX element type 'Swipeout' is not a constructor function for JSX elements. Property 'render' is missing in type 'Swipeout'.