### PR TITLE
fix shrinking children components on every swipe on ios

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -368,7 +368,7 @@ const Swipeout = createReactClass({
     };
     var styleContentPos = {
       content: {
-        left: this._rubberBandEasing(posX, limit),
+        transform: [{ translateX: this._rubberBandEasing(posX, limit) }],
       },
     };
 


### PR DESCRIPTION
Fix for #262 #264 #266 issues
Used 'transformX' instead 'left' for styleContentPos