### PR TITLE
feat: enableScroll props

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ scroll          | func   | Yes      |           | prevent parent scroll
 style           | style  | Yes      |           | style of the container
 sensitivity     | number | Yes      | 50         | change the sensitivity of gesture
 buttonWidth     | number | Yes      |            | each button width
+enableScroll    | bool   | Yes      | true       | if false, the component won't slide horizontally with the button
 
 ##### Button props
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -126,7 +126,8 @@ var Swipeout = (0, _createReactClass2.default)({
     style: (_reactNative.ViewPropTypes || _reactNative.View.propTypes).style,
     sensitivity: _propTypes2.default.number,
     buttonWidth: _propTypes2.default.number,
-    disabled: _propTypes2.default.bool
+    disabled: _propTypes2.default.bool,
+    enableScroll: _propTypes2.default.bool
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -134,7 +135,8 @@ var Swipeout = (0, _createReactClass2.default)({
       disabled: false,
       rowID: -1,
       sectionID: -1,
-      sensitivity: 50
+      sensitivity: 50,
+      enableScroll: true
     };
   },
 
@@ -279,6 +281,9 @@ var Swipeout = (0, _createReactClass2.default)({
   },
 
   _rubberBandEasing: function _rubberBandEasing(value, limit) {
+    if (!this.props.enableScroll) {
+      return 0;
+    }
     if (value < 0 && value < limit) return limit - Math.pow(limit - value, 0.85);else if (value > 0 && value > limit) return limit + Math.pow(value - limit, 0.85);
     return value;
   },

--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,7 @@ const Swipeout = createReactClass({
     sensitivity: PropTypes.number,
     buttonWidth: PropTypes.number,
     disabled: PropTypes.bool,
+    enableScroll: PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -118,6 +119,7 @@ const Swipeout = createReactClass({
       rowID: -1,
       sectionID: -1,
       sensitivity: 50,
+      enableScroll: true
     };
   },
 
@@ -253,6 +255,9 @@ const Swipeout = createReactClass({
   },
 
   _rubberBandEasing: function (value, limit) {
+    if(!this.props.enableScroll){
+      return 0;
+    }
     if (value < 0 && value < limit) return limit - Math.pow(limit - value, 0.85);
     else if (value > 0 && value > limit) return limit + Math.pow(value - limit, 0.85);
     return value;


### PR DESCRIPTION
Sometimes, you don't want the content of the swipeable component to scroll with the button.

The props "enableScroll" allows this behaviour.

Default value is true so there is no breaking change in the api, only a new feature added.