### PR TITLE
Add test ID to the swipe out left/right elements

### DIFF
--- a/dist/TestProps.js
+++ b/dist/TestProps.js
@@ -1,0 +1,19 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.testProps = undefined;
+
+var _reactNative = require('react-native');
+
+var testProps = exports.testProps = function testProps(testId) {
+  if (_reactNative.Platform.OS === 'android') {
+    return { testID: testId, accessibilityLabel: testId };
+  }
+  return { testID: testId };
+}; // TestProps required as React Native for Android doesn't correctly support testIDs
+// as doing so would break Facebooks own automated testing pipeline.  Until
+// Facebook update their internal testing pipeline this is the recommended
+// way to handle this.
+//

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,6 +32,8 @@ var _createReactClass2 = _interopRequireDefault(_createReactClass);
 
 var _reactNative = require('react-native');
 
+var _TestProps = require('./TestProps');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var SwipeoutBtn = (0, _createReactClass2.default)({
@@ -45,7 +47,8 @@ var SwipeoutBtn = (0, _createReactClass2.default)({
     onPress: _propTypes2.default.func,
     text: _propTypes2.default.node,
     type: _propTypes2.default.string,
-    underlayColor: _propTypes2.default.string
+    underlayColor: _propTypes2.default.string,
+    testID: _propTypes2.default.string
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -59,7 +62,8 @@ var SwipeoutBtn = (0, _createReactClass2.default)({
       disabled: false,
       text: 'Click me',
       type: '',
-      width: 0
+      width: 0,
+      testID: null
     };
   },
 
@@ -102,7 +106,9 @@ var SwipeoutBtn = (0, _createReactClass2.default)({
         textStyle: styleSwipeoutBtnText },
       btn.component ? _react2.default.createElement(
         _reactNative.View,
-        { style: styleSwipeoutBtnComponent },
+        _extends({
+          style: styleSwipeoutBtnComponent
+        }, (0, _TestProps.testProps)(btn.testID)),
         btn.component
       ) : btn.text
     );
@@ -195,7 +201,7 @@ var Swipeout = (0, _createReactClass2.default)({
     } else {
       this._callOnClose();
     }
-    this.refs.swipeoutContent.measure(function (ox, oy, width, height) {
+    this.swipeoutContent.measure(function (ox, oy, width, height) {
       var buttonWidth = _this2.props.buttonWidth || width / 5;
       _this2.setState({
         btnWidth: buttonWidth,
@@ -337,7 +343,7 @@ var Swipeout = (0, _createReactClass2.default)({
   _openRight: function _openRight() {
     var _this3 = this;
 
-    this.refs.swipeoutContent.measure(function (ox, oy, width, height) {
+    this.swipeoutContent.measure(function (ox, oy, width, height) {
       var btnWidth = _this3.props.buttonWidth || width / 5;
 
       _this3.setState({
@@ -359,7 +365,7 @@ var Swipeout = (0, _createReactClass2.default)({
   _openLeft: function _openLeft() {
     var _this4 = this;
 
-    this.refs.swipeoutContent.measure(function (ox, oy, width, height) {
+    this.swipeoutContent.measure(function (ox, oy, width, height) {
       var btnWidth = _this4.props.buttonWidth || width / 5;
 
       _this4.setState({
@@ -379,6 +385,8 @@ var Swipeout = (0, _createReactClass2.default)({
   },
 
   render: function render() {
+    var _this5 = this;
+
     var contentWidth = this.state.contentWidth;
     var posX = this.getTweeningValue('contentPos');
 
@@ -427,7 +435,9 @@ var Swipeout = (0, _createReactClass2.default)({
       _react2.default.createElement(
         _reactNative.View,
         _extends({
-          ref: 'swipeoutContent',
+          ref: function ref(node) {
+            return _this5.swipeoutContent = node;
+          },
           style: styleContent,
           onLayout: this._onLayout
         }, this._panResponder.panHandlers),
@@ -462,7 +472,7 @@ var Swipeout = (0, _createReactClass2.default)({
   },
 
   _renderButton: function _renderButton(btn, i) {
-    var _this5 = this;
+    var _this6 = this;
 
     return _react2.default.createElement(SwipeoutBtn, {
       backgroundColor: btn.backgroundColor,
@@ -472,12 +482,13 @@ var Swipeout = (0, _createReactClass2.default)({
       height: this.state.contentHeight,
       key: i,
       onPress: function onPress() {
-        return _this5._autoClose(btn);
+        return _this6._autoClose(btn);
       },
       text: btn.text,
       type: btn.type,
       underlayColor: btn.underlayColor,
-      width: this.state.btnWidth
+      width: this.state.btnWidth,
+      testID: btn.testID
     });
   }
 });

--- a/src/TestProps.js
+++ b/src/TestProps.js
@@ -1,0 +1,14 @@
+// TestProps required as React Native for Android doesn't correctly support testIDs
+// as doing so would break Facebooks own automated testing pipeline.  Until
+// Facebook update their internal testing pipeline this is the recommended
+// way to handle this.
+//
+
+import { Platform } from 'react-native'
+
+export const testProps = (testId) => {
+  if (Platform.OS === 'android') {
+    return { testID: testId, accessibilityLabel: testId }
+  }
+  return { testID: testId }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import {
   View,
   ViewPropTypes,
 } from 'react-native';
+import { testProps } from './TestProps';
 
 const SwipeoutBtn = createReactClass({
 
@@ -27,6 +28,7 @@ const SwipeoutBtn = createReactClass({
     text: PropTypes.node,
     type: PropTypes.string,
     underlayColor: PropTypes.string,
+    testID: PropTypes.string
   },
 
   getDefaultProps: function () {
@@ -41,6 +43,7 @@ const SwipeoutBtn = createReactClass({
       text: 'Click me',
       type: '',
       width: 0,
+      testID: null
     };
   },
 
@@ -84,7 +87,11 @@ const SwipeoutBtn = createReactClass({
         textStyle={styleSwipeoutBtnText}>
         {
           (btn.component ?
-            <View style={styleSwipeoutBtnComponent}>{btn.component}</View>
+            <View
+              style={styleSwipeoutBtnComponent}
+              {...testProps(btn.testID)}
+            >
+              {btn.component}</View>
             :
             btn.text
           )
@@ -434,6 +441,7 @@ const Swipeout = createReactClass({
         type={btn.type}
         underlayColor={btn.underlayColor}
         width={this.state.btnWidth}
+        testID={btn.testID}
       />
     );
   }


### PR DESCRIPTION
This library is limited when it comes to automating swipe left or swipe right. I added test ID so that selenium or any other automation framework can pick up the id to perform the appropriate action.