### PR TITLE
fixed button width for widescreens

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -134,7 +134,8 @@ var Swipeout = (0, _createReactClass2.default)({
       disabled: false,
       rowID: -1,
       sectionID: -1,
-      sensitivity: 50
+      sensitivity: 50,
+      buttonWidth: 80
     };
   },
 
@@ -195,8 +196,8 @@ var Swipeout = (0, _createReactClass2.default)({
     } else {
       this._callOnClose();
     }
-    this.refs.swipeoutContent.measure(function (ox, oy, width, height) {
-      var buttonWidth = _this2.props.buttonWidth || width / 5;
+    this.swipeoutContent.measure(function (ox, oy, width, height) {
+      var buttonWidth = _this2.props.buttonWidth;
       _this2.setState({
         btnWidth: buttonWidth,
         btnsLeftWidth: _this2.props.left ? buttonWidth * _this2.props.left.length : 0,
@@ -337,8 +338,8 @@ var Swipeout = (0, _createReactClass2.default)({
   _openRight: function _openRight() {
     var _this3 = this;
 
-    this.refs.swipeoutContent.measure(function (ox, oy, width, height) {
-      var btnWidth = _this3.props.buttonWidth || width / 5;
+    this.swipeoutContent.measure(function (ox, oy, width, height) {
+      var btnWidth = _this3.props.buttonWidth;
 
       _this3.setState({
         btnWidth: btnWidth,
@@ -359,8 +360,8 @@ var Swipeout = (0, _createReactClass2.default)({
   _openLeft: function _openLeft() {
     var _this4 = this;
 
-    this.refs.swipeoutContent.measure(function (ox, oy, width, height) {
-      var btnWidth = _this4.props.buttonWidth || width / 5;
+    this.swipeoutContent.measure(function (ox, oy, width, height) {
+      var btnWidth = _this4.props.buttonWidth;
 
       _this4.setState({
         btnWidth: btnWidth,
@@ -379,6 +380,8 @@ var Swipeout = (0, _createReactClass2.default)({
   },
 
   render: function render() {
+    var _this5 = this;
+
     var contentWidth = this.state.contentWidth;
     var posX = this.getTweeningValue('contentPos');
 
@@ -427,7 +430,9 @@ var Swipeout = (0, _createReactClass2.default)({
       _react2.default.createElement(
         _reactNative.View,
         _extends({
-          ref: 'swipeoutContent',
+          ref: function ref(node) {
+            return _this5.swipeoutContent = node;
+          },
           style: styleContent,
           onLayout: this._onLayout
         }, this._panResponder.panHandlers),
@@ -462,7 +467,7 @@ var Swipeout = (0, _createReactClass2.default)({
   },
 
   _renderButton: function _renderButton(btn, i) {
-    var _this5 = this;
+    var _this6 = this;
 
     return _react2.default.createElement(SwipeoutBtn, {
       backgroundColor: btn.backgroundColor,
@@ -472,7 +477,7 @@ var Swipeout = (0, _createReactClass2.default)({
       height: this.state.contentHeight,
       key: i,
       onPress: function onPress() {
-        return _this5._autoClose(btn);
+        return _this6._autoClose(btn);
       },
       text: btn.text,
       type: btn.type,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-swipeout",
-  "version": "2.3.4",
+  "version": "2.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1519,12 +1519,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1539,17 +1541,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1666,7 +1671,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1678,6 +1684,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1692,6 +1699,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1699,12 +1707,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1723,6 +1733,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1803,7 +1814,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1815,6 +1827,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1936,6 +1949,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,7 @@ const Swipeout = createReactClass({
       rowID: -1,
       sectionID: -1,
       sensitivity: 50,
+      buttonWidth: 80,
     };
   },
 
@@ -168,7 +169,7 @@ const Swipeout = createReactClass({
       this._callOnClose();
     }
     this.swipeoutContent.measure((ox, oy, width, height) => {
-      let buttonWidth = this.props.buttonWidth || (width / 5);
+      let buttonWidth = this.props.buttonWidth;
       this.setState({
         btnWidth: buttonWidth,
         btnsLeftWidth: this.props.left ? buttonWidth * this.props.left.length : 0,
@@ -303,7 +304,7 @@ const Swipeout = createReactClass({
 
   _openRight: function () {
     this.swipeoutContent.measure((ox, oy, width, height) => {
-      let btnWidth = this.props.buttonWidth || (width / 5);
+      let btnWidth = this.props.buttonWidth;
 
       this.setState({
         btnWidth,
@@ -323,7 +324,7 @@ const Swipeout = createReactClass({
 
   _openLeft: function () {
     this.swipeoutContent.measure((ox, oy, width, height) => {
-      let btnWidth = this.props.buttonWidth || (width / 5);
+      let btnWidth = this.props.buttonWidth;
 
       this.setState({
         btnWidth,


### PR DESCRIPTION
Fixed width of button to properly support widescreens. Previously it took 1/5 of the screen.

This fixes [this](https://github.com/dancormier/react-native-swipeout/issues/306) bug.

Item:
![list_item](https://user-images.githubusercontent.com/12607663/48003522-f4580100-e10e-11e8-85d6-a29326fa861d.png)
Before:
![list_item_one_button](https://user-images.githubusercontent.com/12607663/48003529-fae67880-e10e-11e8-9981-3ba3f08e09a7.png)
![list_item_two_button](https://user-images.githubusercontent.com/12607663/48003526-f91cb500-e10e-11e8-99c2-606fa7b97087.png)
After:
![screenshot_20181108_170749](https://user-images.githubusercontent.com/12607663/48211229-5c118480-e379-11e8-9f83-5f06d3f1d612.png)
![screenshot_20181108_170708](https://user-images.githubusercontent.com/12607663/48211230-5e73de80-e379-11e8-932e-c64c826fbb2b.png)

Maybe 80 is not the best solution. We should discuss this.

