### PR TITLE
Modify PanHandlers to ensure that a touchable element won't block the swiping event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ const Swipeout = createReactClass({
       disabled: false,
       rowID: -1,
       sectionID: -1,
-      sensitivity: 50,
+      sensitivity: 0,
     };
   },
 
@@ -131,6 +131,7 @@ const Swipeout = createReactClass({
       contentPos: 0,
       contentWidth: 0,
       openedRight: false,
+      openedLeft: false,
       swiping: false,
       tweenDuration: 160,
       timeStart: null,
@@ -145,11 +146,11 @@ const Swipeout = createReactClass({
       onMoveShouldSetPanResponderCapture: (event, gestureState) =>
         Math.abs(gestureState.dx) > this.props.sensitivity &&
         Math.abs(gestureState.dy) <= this.props.sensitivity,
-      onPanResponderGrant: this._handlePanResponderGrant,
+    onPanResponderGrant: this._handlePanResponderGrant,
       onPanResponderMove: this._handlePanResponderMove,
       onPanResponderRelease: this._handlePanResponderEnd,
       onPanResponderTerminate: this._handlePanResponderEnd,
-      onShouldBlockNativeResponder: (event, gestureState) => false,
+      onShouldBlockNativeResponder: (event, gestureState) => true,
       onPanResponderTerminationRequest: () => false,
     });
   },


### PR DESCRIPTION
Related to: https://github.com/dancormier/react-native-swipeout/issues/217