### PR TITLE
swipeoutContent don't take all available space

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -30,6 +30,7 @@ const styles = StyleSheet.create({
     top: 0,
   },
   swipeoutContent: {
+    flex: 1,
   },
   colorDelete: {
     backgroundColor: '#fb3d38',


### PR DESCRIPTION
Add flex 1 to swipeoutContent, size style can be override in parent.

Before:
<img width="1182" alt="screenshot 2019-01-16 at 11 47 02" src="https://user-images.githubusercontent.com/3551795/51244387-475af980-1985-11e9-84b5-9b5e5a066c33.png">

After:
<img width="1189" alt="screenshot 2019-01-16 at 11 47 25" src="https://user-images.githubusercontent.com/3551795/51244394-4cb84400-1985-11e9-905d-c16ef1de0bd8.png">
