### PR TITLE
fix: export right interface with right props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare module 'react-native-swipeout' {
         style?: Object;
         sensitivity?: number;
         buttonWidth?: number;
-        rowId?: number;
+        rowID?: number;
         sectionId?: number;
         openRight?: boolean;
         openLeft?: boolean;


### PR DESCRIPTION
The package is exporting an interface SwipeoutProperties from 'index.d.ts',
this interface has a prop named 'rowId' but this prop is not supported in the
package. The prop that is supported in package is 'rowID'. Because of this user
was getting wrong intellisense in the editor and even after updating row id in props
wasn't getting updated. 